### PR TITLE
“Maximum call stack size exceeded” while running with PhantomJS

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -1,3 +1,5 @@
+var should;
+
 (function(window) {
   window.should = window.chai.should();
   window.expect = window.chai.expect;


### PR DESCRIPTION
Error message:

```
PhantomJS 1.9.1 (Mac OS X) ERROR
    RangeError: Maximum call stack size exceeded.
    at /.../node_modules/karma-chai/node_modules/chai/chai.js:2863
PhantomJS 1.9.1 (Mac OS X): Executed 0 of 0 ERROR (0.026 secs / 0 secs
```

Workaround described at https://github.com/chaijs/chai/issues/107.
