### PR TITLE
Bumping chai version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "groc": "~0.4.0"
   },
   "dependencies": {
-    "chai": "~1.6.1"
+    "chai": "~1.8.1"
   },
   "peerDependencies": {
     "karma": ">=0.9"


### PR DESCRIPTION
Browserify is messed-up by dynamic require.

cf. chaijs/type-detect#1 and chaijs/deep-eql#1
