### PR TITLE
Fix "Maximum call stack size exceeded" in PhantomJS... again

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -1,6 +1,5 @@
-var should;
-
 (function(window) {
+  window.should = null; // Workaround for "RangeError: Maximum call stack size exceeded." in PhantomJS
   window.should = window.chai.should();
   window.expect = window.chai.expect;
   window.assert = window.chai.assert;


### PR DESCRIPTION
This addresses the same issue as #1, which didn't seem to be sufficient to solve the problem.

This PR employs the fix mentioned [here](https://github.com/hydrojs/chai/issues/2#issuecomment-31518630) and [here](https://github.com/chaijs/chai/issues/107#issuecomment-39917970).
